### PR TITLE
Get libgit2 and godep playing nicely together.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.4
+
+ENV PKG /go/src/github.com/docker/docker-network
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR ${PKG}
+VOLUME ${PKG}
+
+RUN apt-get update && apt-get install build-essential cmake pkg-config openssh-client -y
+
+# Get libgit2
+ENV LIBGIT2=github.com/tiborvass/git2go
+ENV LIBGIT2_ORIG=github.com/libgit2/git2go
+RUN go get -d ${LIBGIT2} && \
+  mkdir -p /go/src/$(dirname ${LIBGIT2_ORIG}) && \
+  mv /go/src/${LIBGIT2} /go/src/${LIBGIT2_ORIG} && \
+  cd /go/src/${LIBGIT2_ORIG} && \
+  git checkout origin/go_backends && \
+  git submodule update --init && \
+  make install
+
+RUN go get github.com/kr/godep
+
+ENTRYPOINT ["/bin/sh", "entrypoint.sh"]
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 PKG:=github.com/docker/docker-network
 PKG_PATH:=/go/src/$(PKG)
-RUN_CMD:=docker run --privileged --rm -v "$(shell pwd)":$(PKG_PATH) -w $(PKG_PATH) golang:1.4 go
+RUN_CMD:=docker run --privileged --rm -v "$(shell pwd)":$(PKG_PATH) docker-network
 
-build:
-	$(RUN_CMD) build -v
+build: dockerbuild
+	$(RUN_CMD) go build -v
 
-test:
-	$(RUN_CMD) test -v ./...
+test: dockerbuild
+	$(RUN_CMD) go test -v ./...
+
+save: dockerbuild
+	$(RUN_CMD) 'go get -d ./... && godep save -r ./...'
+
+dockerbuild:
+	docker build -t docker-network .
+
+clean:
+	docker rmi -f docker-network
+	rm -f docker-network

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+godep restore && sh -c "$*"


### PR DESCRIPTION
Ok.

I realize some of this code is extremely weird, but this gets godep and libgit2 playing nicely together. It also establishes a very simple micro-workflow that is not perfect but _is_ functional without a lot of knowledge of the source code. Presuming you already have git2go (well, at least tibor's fork) installed, you should also be able to `go get` directly too.

 `godep save` is also containerized allowing you to do all sorts of naughty things to your local environment and then the container build system will just pick it up and rewrite your imports for you. 
